### PR TITLE
Fix: data 타입 차이로 인한 상세페이지 이동 오류 수정

### DIFF
--- a/src/feature/home/components/VideoItem.tsx
+++ b/src/feature/home/components/VideoItem.tsx
@@ -19,12 +19,12 @@ const VideoItem = React.memo(({ item }: VideoItemProps) => {
 
   return (
     <li className="mb-5 w-full">
-      <VideoThumbnail videoId={item.id} thumbnailUrl={item.snippet.thumbnails.high.url} />
+      <VideoThumbnail videoId={typeof item.id === 'string' ? item.id : item.id.videoId} thumbnailUrl={item.snippet.thumbnails.high.url} />
 
       <div className="flex items-start gap-3">
         <ChannelAvatar channelId={item.snippet.channelId} channelThumbnail={channelThumbnail} />
         <VideoInfo
-          videoId={item.id}
+          videoId={typeof item.id === 'string' ? item.id : item.id.videoId}
           title={item.snippet.title}
           viewCount={Number(item.statistics.viewCount)}
           publishedAt={item.snippet.publishedAt}

--- a/src/shared/type/IYouTubeTypes.ts
+++ b/src/shared/type/IYouTubeTypes.ts
@@ -24,7 +24,7 @@ export interface YouTubeStatistics {
 
 // 기본 비디오 아이템 (홈 화면용)
 export interface YouTubeVideoItem {
-  id: string
+  id: string | { videoId: string }
   snippet: YouTubeSnippet
   statistics: YouTubeStatistics
 }


### PR DESCRIPTION
## 📝 변경사항

- [x] youtube api 사용시 넘어오는 데이터 형식이 달라 동영상 상세페이지 이동 시 videoId가 객체형태로 넘어가는 오류 발견되어 수정했습니다.
