### PR TITLE
Fix: 검색 시 비디오 제목 깨지는 현상

### DIFF
--- a/src/shared/components/video/VideoInfo.tsx
+++ b/src/shared/components/video/VideoInfo.tsx
@@ -1,12 +1,13 @@
 import { formatUploadDate, formatViewCount } from '@/shared/util/format'
 import { Link } from 'react-router-dom'
 import VideoInfoProps from './type/IVideoInfoProps'
+import decodeHtmlEntities from './util/decodeHtmlEntities'
 
 const VideoInfo = ({ videoId, title, viewCount, publishedAt }: VideoInfoProps) => {
   return (
     <div className="flex flex-1 flex-col gap-1">
       <Link to={`/watch?video=${videoId}`} className="line-clamp-2 text-base font-medium">
-        {title}
+        {decodeHtmlEntities(title)}
       </Link>
       <div className="text-sm font-light text-gray-medium-dark">
         <span>조회수 {formatViewCount(viewCount)}</span>

--- a/src/shared/components/video/util/decodeHtmlEntities.ts
+++ b/src/shared/components/video/util/decodeHtmlEntities.ts
@@ -1,0 +1,10 @@
+/**
+ * HTML 엔티티로 인코딩된 문자열을 디코딩합니다.
+ * 예: "&quot;Hello&quot;" -> "\"Hello\""
+ */
+const decodeHtmlEntities = (html: string): string => {
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  return doc.documentElement.textContent || html
+}
+
+export default decodeHtmlEntities


### PR DESCRIPTION
## 📝 변경사항
- [x] youtube search api에서 넘어오는 결과에 특수문자가 html entities 형태로 인코딩되어 넘어와서 디코딩 함수 추가

## 🙋 기타 코멘트
### 적용전
![image](https://github.com/user-attachments/assets/a8163a2a-78ce-47d4-a055-d8c9ad65c3ab)

### 적용후
![image](https://github.com/user-attachments/assets/42a081de-2287-412c-9c64-dbf643f0d35c)

