### PR TITLE
Fix: 아이유 검색 시 첫번째 플레이리스트에서 비디오 목록 모달 안뜨는 현상 수정

### DIFF
--- a/src/feature/playlist/api/usePlayListVideoInfo.ts
+++ b/src/feature/playlist/api/usePlayListVideoInfo.ts
@@ -49,7 +49,7 @@ const usePlayListVideoInfo = (playListId: string, myself: boolean) => {
         return items.map((item) => ({
           id: item.snippet.resourceId.videoId,
           title: item.snippet.title,
-          thumbnailUrl: item.snippet.thumbnails.high.url || '/public/image/default/thumbnail.png',
+          thumbnailUrl: item.snippet.thumbnails?.high?.url ?? '/public/image/default/thumbnail.png',
           ownerName: item.snippet.videoOwnerChannelTitle,
         }))
       }

--- a/src/feature/playlist/components/PlayListVideoItem.tsx
+++ b/src/feature/playlist/components/PlayListVideoItem.tsx
@@ -18,7 +18,7 @@ const PlaylistVideoItem = ({ videoId, title, thumbnailUrl }: Omit<IVideoItemProp
       className={`scrollbar-hide flex h-[132px] cursor-pointer items-start gap-[15px] px-[15px] py-[10px] ${videoId === currentVideoId ? 'bg-gray-light' : ''}`}
     >
       {/* 썸네일 */}
-      <img src={thumbnailUrl} alt={title} className="h-[112px] w-[180px] rounded-md object-cover" />
+      <img src={thumbnailUrl} alt={title} className="aspect-video w-[180px] rounded-md object-cover" />
 
       {/* 텍스트 영역 */}
       <div className="flex flex-1 flex-col justify-between gap-[8px] overflow-hidden">

--- a/src/feature/playlist/components/PlayListVideoItem.tsx
+++ b/src/feature/playlist/components/PlayListVideoItem.tsx
@@ -15,7 +15,7 @@ const PlaylistVideoItem = ({ videoId, title, thumbnailUrl }: Omit<IVideoItemProp
 
   return (
     <div
-      className={`scrollbar-hide flex h-[132px] cursor-pointer items-start gap-[15px] px-[15px] py-[10px] ${videoId === currentVideoId ? 'bg-gray-light' : ''}`}
+      className={`scrollbar-hide flex h-[132px] items-start gap-[15px] px-[15px] py-[10px] ${title === 'Deleted video' ? 'cursor-not-allowed' : 'cursor-pointer'} ${videoId === currentVideoId ? 'bg-gray-light' : ''}`}
     >
       {/* 썸네일 */}
       <img src={thumbnailUrl} alt={title} className="aspect-video w-[180px] rounded-md object-cover" />

--- a/src/feature/playlist/components/PlaylistFullModal.tsx
+++ b/src/feature/playlist/components/PlaylistFullModal.tsx
@@ -23,14 +23,15 @@ const PlaylistFullModal = ({ playList, playListInfo, myself, setIsFullOpen }: IP
         />
 
         <div className="scrollbar-hide flex-1 overflow-y-auto px-[2px]">
-          {playList.map((video, index) => {
-            return (
-              // Link to supabase || youtube 구분해줘야함 myself 넣어서
+          {playList.map((video, index) =>
+            video.title === 'Deleted video' ? (
+              <PlaylistVideoItem key={video.id} videoId={video.id} title={video.title} thumbnailUrl={video.thumbnailUrl} />
+            ) : (
               <Link to={`/watch?video=${video.id}&playlist=${playListInfo.id}${myself ? '&myself=true' : ''}`} key={index}>
                 <PlaylistVideoItem key={video.id} videoId={video.id} title={video.title} thumbnailUrl={video.thumbnailUrl} />
               </Link>
-            )
-          })}
+            ),
+          )}
         </div>
       </motion.div>
     </AnimatePresence>

--- a/src/feature/playlist/components/PlaylistFullModal.tsx
+++ b/src/feature/playlist/components/PlaylistFullModal.tsx
@@ -12,7 +12,7 @@ const PlaylistFullModal = ({ playList, playListInfo, myself, setIsFullOpen }: IP
         animate={{ y: '0%', opacity: 1 }}
         exit={{ y: '100%', opacity: 0 }}
         transition={{ duration: 0.3, ease: 'easeInOut' }}
-        className="fixed bottom-[56px] top-[300px] z-50 flex w-[430px] flex-col bg-white shadow-xl"
+        className="fixed bottom-[56px] top-[300px] z-50 flex w-[430px] flex-col bg-basic-white shadow-xl"
       >
         <PlaylistHeader
           playlistTitle={playListInfo.title}


### PR DESCRIPTION
## 📝 변경사항

- [x] 플레이리스트에 삭제된 비디오 포함시 썸네일이 빈 객체로 넘어오면서 생기는 현상이라 해당되는 코드 수정했습니다.
- [x] 다크 모드 적용시 배경 색상이 안바뀌어서 className 수정했습니다.
- [x] 플레이리스트에 포함된 비디오 썸네일에 상하로 검은 줄이 있어서 해당 부분 스타일 수정했습니다.

## 스크린샷
<img width="431" alt="image" src="https://github.com/user-attachments/assets/604d052e-a28d-4937-ad7d-a53916a027c8" />
